### PR TITLE
Bump up ecmaVersion to 2020

### DIFF
--- a/base.js
+++ b/base.js
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
   },
   extends: [
     'airbnb-base',


### PR DESCRIPTION
Bumping ecmaVersion to 2020 in order to use new JS features in Strapi codebase 