### PR TITLE
enhancement: add consistent type rules to TS configs

### DIFF
--- a/back/typescript.js
+++ b/back/typescript.js
@@ -13,5 +13,12 @@ module.exports = {
     ],
     // @see: https://github.com/typescript-eslint/typescript-eslint/issues/1824
     '@typescript-eslint/indent': 'off',
+    /**
+     * Ensures the use of import and export as type when possible.
+     * @see: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/
+     */
+    '@typescript-eslint/consistent-type-exports': 'warning',
+    '@typescript-eslint/consistent-type-imports': 'warning',
+    '@typescript-eslint/no-import-type-side-effects': 'warning',
   },
 };

--- a/back/typescript.js
+++ b/back/typescript.js
@@ -17,8 +17,8 @@ module.exports = {
      * Ensures the use of import and export as type when possible.
      * @see: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/
      */
-    '@typescript-eslint/consistent-type-exports': 'warning',
-    '@typescript-eslint/consistent-type-imports': 'warning',
-    '@typescript-eslint/no-import-type-side-effects': 'warning',
+    '@typescript-eslint/consistent-type-exports': 'error',
+    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/no-import-type-side-effects': 'error',
   },
 };

--- a/front/typescript.js
+++ b/front/typescript.js
@@ -102,6 +102,13 @@ module.exports = {
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
     ],
     /**
+     * Ensures the use of import and export as type when possible.
+     * @see: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/
+     */
+    '@typescript-eslint/consistent-type-exports': 'warning',
+    '@typescript-eslint/consistent-type-imports': 'warning',
+    '@typescript-eslint/no-import-type-side-effects': 'warning',
+    /**
      * Currently, we allow:
      *
      * ```jsx

--- a/front/typescript.js
+++ b/front/typescript.js
@@ -105,9 +105,9 @@ module.exports = {
      * Ensures the use of import and export as type when possible.
      * @see: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/
      */
-    '@typescript-eslint/consistent-type-exports': 'warning',
-    '@typescript-eslint/consistent-type-imports': 'warning',
-    '@typescript-eslint/no-import-type-side-effects': 'warning',
+    '@typescript-eslint/consistent-type-exports': 'error',
+    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/no-import-type-side-effects': 'error',
     /**
      * Currently, we allow:
      *


### PR DESCRIPTION
Adds rules to force the use of import type when possible. The reasons are detailed in this post: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/

It's something that would come up very regularly in PR reviews, when ESLint can take care of it. It also means we can do one big autofix PR on the monorepo.

I'm not sure if there's a better place to put this, if errors would be better, or if this is a breaking change. Let me know!